### PR TITLE
Fixes for Audio Timeout Error

### DIFF
--- a/lib/gcloud/speech_api/streaming_client/connection.ex
+++ b/lib/gcloud/speech_api/streaming_client/connection.ex
@@ -65,7 +65,7 @@ defmodule GCloud.SpeechAPI.Streaming.Client.Connection do
 
   defp grpc_receive(%{stream: stream, recv_enum: nil} = state) do
     # recv reads process mailbox (messages from :gun library)
-    res = GRPC.Stub.recv(stream, timeout: @timeout)
+    res = GRPC.Stub.recv(stream, timeout: 0)
 
     case res do
       {:ok, enum} -> grpc_receive(%{state | recv_enum: enum})

--- a/lib/gcloud/speech_api/streaming_client/connection.ex
+++ b/lib/gcloud/speech_api/streaming_client/connection.ex
@@ -127,8 +127,8 @@ defmodule GCloud.SpeechAPI.Streaming.Client.Connection do
     exit(:normal)
   end
 
-  defp handle_error(error, _state) do
-    Logger.error(inspect(error))
+  defp handle_error(error, state) do
+    Logger.error("[#{inspect(state.target)}]" <> inspect(error))
     exit(:error)
   end
 end


### PR DESCRIPTION
Use timeout: 0 when waiting for transcriptions
This can improve the responsiveness of the connection process
since only cast-like messages will be awaited with a non-zero timeout